### PR TITLE
fix(vibe-cloud-ui): Correct Dockerfile for static asset handling

### DIFF
--- a/apps/vibe-cloud-ui/Dockerfile
+++ b/apps/vibe-cloud-ui/Dockerfile
@@ -42,12 +42,6 @@ RUN adduser --system --uid 1001 nextjs
 # Copy the standalone output
 COPY --from=builder --chown=nextjs:nodejs /repo/apps/vibe-cloud-ui/.next/standalone ./
 
-# Copy the static assets
-COPY --from=builder --chown=nextjs:nodejs /repo/apps/vibe-cloud-ui/.next/static ./.next/static
-
-# Copy the public assets
-COPY --from=builder --chown=nextjs:nodejs /repo/apps/vibe-cloud-ui/public ./public
-
 USER nextjs
 EXPOSE 4000
 CMD ["node", "server.js"]


### PR DESCRIPTION
The vibe-cloud-ui application was failing to load static assets in the production environment, resulting in 404 errors. This was caused by a misconfiguration in the Dockerfile.

For modern versions of Next.js (v12.2.0+), the `output: 'standalone'` option in `next.config.js` creates a self-contained directory that includes the `.next/static` and `public` folders.

The previous Dockerfile contained redundant `COPY` commands that explicitly copied these directories after the `standalone` directory was already copied. This was unnecessary and likely causing a conflict or incorrect file structure in the final image.

This commit simplifies the Dockerfile by removing the redundant `COPY` commands, relying on the `standalone` output as the single source of truth for the application files. This aligns the build process with modern Next.js best practices and resolves the 404 errors for static assets.